### PR TITLE
fix(search): implement JSON response parsing for Search API

### DIFF
--- a/cli/pkg/api/client_test.go
+++ b/cli/pkg/api/client_test.go
@@ -246,44 +246,48 @@ func TestParseSearchResults(t *testing.T) {
 	tests := []struct {
 		name    string
 		content string
-		format  string
 		wantLen int
 	}{
 		{
 			name:    "empty content",
 			content: "",
-			format:  "",
 			wantLen: 0,
 		},
 		{
 			name:    "single line",
 			content: "Single result",
-			format:  "",
 			wantLen: 1,
 		},
 		{
 			name:    "multiple lines",
 			content: "Result 1\nResult 2\nResult 3",
-			format:  "",
 			wantLen: 3,
 		},
 		{
 			name:    "lines with empty lines",
 			content: "Result 1\n\nResult 2\n  \nResult 3",
-			format:  "",
 			wantLen: 3,
 		},
 		{
-			name:    "JSON format (not implemented yet)",
+			name:    "JSON empty array",
 			content: "[]",
-			format:  "json",
 			wantLen: 0,
+		},
+		{
+			name:    "JSON object with data array",
+			content: `{"code":200,"data":[{"title":"Result 1","url":"https://example.com","content":"Content 1"},{"title":"Result 2","url":"https://example2.com","content":"Content 2"}]}`,
+			wantLen: 2,
+		},
+		{
+			name:    "JSON array of objects",
+			content: `[{"title":"A","url":"https://a.com","content":"aaa"},{"title":"B","url":"https://b.com","content":"bbb"}]`,
+			wantLen: 2,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			results := parseSearchResults(tt.content, tt.format)
+			results := parseSearchResults(tt.content)
 			if len(results) != tt.wantLen {
 				t.Errorf("parseSearchResults() len = %d, want %d", len(results), tt.wantLen)
 			}


### PR DESCRIPTION
## Summary

- **Bug**: `jina search` always returns 0 results because `parseSearchResults()` has an unimplemented TODO for JSON parsing — it returns empty results when the response starts with `{` or `[`
- **Root cause**: Jina Search API returns `{"code":200,"data":[...]}` JSON format, but the parser only handled plain text line-by-line splitting
- **Fix**:
  - Add `Accept: application/json` header to search requests to ensure structured JSON responses
  - Add `X-Respond-With` header to forward user-specified response format
  - Implement JSON parsing for both `{"data":[...]}` object format and `[...]` array format
  - Retain plain text line splitting as fallback

## Changes

- `cli/pkg/api/client.go`: Add `encoding/json` import, set proper request headers, rewrite `parseSearchResults()` with JSON support
- `cli/pkg/api/client_test.go`: Update tests to match new function signature, add test cases for JSON object and JSON array parsing

## Test plan

- [x] `go test ./...` — all tests pass
- [x] `jina read --url "https://example.com"` — still works
- [x] `jina search --query "Claude Code CLI" --limit 3` — now returns results (was 0 before)